### PR TITLE
Configurability

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,14 +1,14 @@
 = Redmine Email Notification Content Filter
 
-Redmine Email Notification Content Filter plugin allows to remove the description in the notification emails
+Redmine Email Notification Content Filter plugin allows to configure contents in the notification emails
 
 == Compatibility
 
-This plugin works (has been tested) with redmine v1.4
+This plugin works (has been tested) with redmine v2.2
 
 == Installation
 
-* Place the plugin into  +/path/to/redmine/vendor/plugins+ . The name of the plugin's directory/folder should be *redmine_email_notification_content_filter*.
+* Place the plugin into  +/path/to/redmine/plugins+ . The name of the plugin's directory/folder should be *redmine_email_notification_content_filter*.
 * Restart redmine.
 
 == Usage
@@ -16,9 +16,6 @@ This plugin works (has been tested) with redmine v1.4
 To enable/disable the description in notification emails:
 
 1. Login to Redmine as an Administrator
-2. Browse to the Administration panel
-3. Enter the "Projects" area
-4. Select the project to configure
-5. Select the "Modules" panel
-6. To disable the description in emails, check the "Email notification content filter" checkbox. To enable the description in emails, uncheck the "Email notification content filter" checkbox.
-
+2. Enter inside a project
+3. Select "Settings" tab
+4. Select "Notification content filter" tab

--- a/app/controllers/email_notification_content_filter_controller.rb
+++ b/app/controllers/email_notification_content_filter_controller.rb
@@ -1,0 +1,19 @@
+class EmailNotificationContentFilterController < ApplicationController
+  unloadable
+
+  before_filter :find_project_by_project_id
+  #before_filter :authorize
+
+  helper :custom_fields
+
+  def update
+    configured_fields = EmailNotificationContentFilterConfig.parse_configured_fields(params[:resources])
+    if request.put? && !configured_fields.blank? && EmailNotificationContentFilterConfig.update(@project, configured_fields)
+      flash[:notice] = l(:notice_successful_update)
+    else
+      flash[:error] = l(:notice_email_notification_content_filter_failed_to_save_config)
+    end
+
+    redirect_to settings_project_path(@project, :tab => 'email_filter')
+  end
+end

--- a/app/controllers/email_notification_content_filter_controller.rb
+++ b/app/controllers/email_notification_content_filter_controller.rb
@@ -4,8 +4,6 @@ class EmailNotificationContentFilterController < ApplicationController
   before_filter :find_project_by_project_id
   #before_filter :authorize
 
-  helper :custom_fields
-
   def update
     configured_fields = EmailNotificationContentFilterConfig.parse_configured_fields(params[:resources])
     if request.put? && !configured_fields.blank? && EmailNotificationContentFilterConfig.update(@project, configured_fields)

--- a/app/controllers/email_notification_content_filter_controller.rb
+++ b/app/controllers/email_notification_content_filter_controller.rb
@@ -2,7 +2,7 @@ class EmailNotificationContentFilterController < ApplicationController
   unloadable
 
   before_filter :find_project_by_project_id
-  #before_filter :authorize
+  before_filter :authorize
 
   def update
     configured_fields = EmailNotificationContentFilterConfig.parse_configured_fields(params[:resources])

--- a/app/helpers/email_notification_content_filter_helper.rb
+++ b/app/helpers/email_notification_content_filter_helper.rb
@@ -1,0 +1,2 @@
+module EmailNotificationContentFilterHelper
+end

--- a/app/models/email_notification_content_filter_config.rb
+++ b/app/models/email_notification_content_filter_config.rb
@@ -25,6 +25,19 @@ class EmailNotificationContentFilterConfig < ActiveRecord::Base
     end
   end
 
+  def self.must_hide_field?(project_config, field_name)
+    saved_config = project_config.find {|conf| conf.field_name == field_name || conf.custom_field_id.to_s == field_name.to_s }
+    (saved_config && !saved_config.active?) || false
+  end
+
+  def self.static_field_to_hide_names(project_config)
+    project_config.select{|conf| !conf.field_name.nil? && !conf.active?}.map(&:field_name)
+  end
+
+  def self.issue_custom_field_to_remove_ids(project_config)
+    project_config.select {|conf| !conf.custom_field_id.blank? && !conf.active?}.map(&:custom_field_id)
+  end
+
   def self.configurable_fields_for_project(project)
     saved_static_fields_for_project = saved_static_configurable_fields_by_name(project)
     saved_configurable_issue_custom_fields_for_project = saved_configurable_issue_custom_fields_by_id(project)
@@ -99,12 +112,18 @@ class EmailNotificationContentFilterConfig < ActiveRecord::Base
 
   def self.static_configurable_fields(project, saved_fields_for_project_by_name)
     [
+      ConfigurableField.new(:name => 'project_name', :active => saved_static_configurable_field_is_active?('project_name', saved_fields_for_project_by_name), :label => I18n.t(:label_project), :is_static => true),
+      ConfigurableField.new(:name => 'tracker_name', :active => saved_static_configurable_field_is_active?('tracker_name', saved_fields_for_project_by_name), :label => I18n.t(:label_tracker), :is_static => true),
+      ConfigurableField.new(:name => 'description', :active => saved_static_configurable_field_is_active?('description', saved_fields_for_project_by_name), :label => I18n.t(:field_description), :is_static => true),
+      ConfigurableField.new(:name => 'subject', :active => saved_static_configurable_field_is_active?('subject', saved_fields_for_project_by_name), :label => I18n.t(:field_subject), :is_static => true),
       ConfigurableField.new(:name => 'author', :active => saved_static_configurable_field_is_active?('author', saved_fields_for_project_by_name), :label => I18n.t(:field_author), :is_static => true),
       ConfigurableField.new(:name => 'status', :active => saved_static_configurable_field_is_active?('status', saved_fields_for_project_by_name), :label => I18n.t(:field_status), :is_static => true),
       ConfigurableField.new(:name => 'priority', :active => saved_static_configurable_field_is_active?('priority', saved_fields_for_project_by_name), :label => I18n.t(:field_priority), :is_static => true),
       ConfigurableField.new(:name => 'assigned_to', :active => saved_static_configurable_field_is_active?('assigned_to', saved_fields_for_project_by_name), :label => I18n.t(:field_assigned_to), :is_static => true),
       ConfigurableField.new(:name => 'category', :active => saved_static_configurable_field_is_active?('category', saved_fields_for_project_by_name), :label => I18n.t(:field_category), :is_static => true),
-      ConfigurableField.new(:name => 'fixed_version', :active => saved_static_configurable_field_is_active?('fixed_version', saved_fields_for_project_by_name), :label => I18n.t(:field_fixed_version), :is_static => true)
+      ConfigurableField.new(:name => 'fixed_version', :active => saved_static_configurable_field_is_active?('fixed_version', saved_fields_for_project_by_name), :label => I18n.t(:field_fixed_version), :is_static => true),
+      ConfigurableField.new(:name => 'journal_details', :active => saved_static_configurable_field_is_active?('journal_details', saved_fields_for_project_by_name), :label => I18n.t(:label_details), :is_static => true),
+      ConfigurableField.new(:name => 'journal_notes', :active => saved_static_configurable_field_is_active?('journal_notes', saved_fields_for_project_by_name), :label => I18n.t(:field_notes), :is_static => true)
     ]
   end
 

--- a/app/models/email_notification_content_filter_config.rb
+++ b/app/models/email_notification_content_filter_config.rb
@@ -1,0 +1,116 @@
+class EmailNotificationContentFilterConfig < ActiveRecord::Base
+  unloadable
+
+  belongs_to :project
+  belongs_to :custom_field, :conditions => {:type => 'IssueCustomField'}
+
+  scope :static_fields, :conditions => 'field_name IS NOT NULL'
+  scope :issue_custom_fields, :conditions => 'custom_field_id IS NOT NULL'
+
+  class ConfigurableField
+    attr_accessor :name, :active, :label, :is_static
+
+    def initialize(fields = {})
+      fields.each do |field_name, field_value|
+        self.send("#{field_name}=", field_value)
+      end
+    end
+
+    def active?
+      !active.blank?
+    end
+
+    def is_static?
+      is_static == 'true' || is_static == true
+    end
+  end
+
+  def self.configurable_fields_for_project(project)
+    saved_static_fields_for_project = saved_static_configurable_fields_by_name(project)
+    saved_configurable_issue_custom_fields_for_project = saved_configurable_issue_custom_fields_by_id(project)
+
+    static_configurable_fields(project, saved_static_fields_for_project) + configurable_issue_custom_fields(project, saved_configurable_issue_custom_fields_for_project)
+  end
+
+  def self.parse_configured_fields(configurable_fields_params)
+    configurable_fields_params.values.map do |configurable_field_param|
+      ConfigurableField.new(:name => configurable_field_param[:name], :active => configurable_field_param[:active], :is_static => configurable_field_param[:is_static])
+    end
+  end
+
+  def self.update(project, sent_configured_fields)
+    to_save = []
+    to_delete = []
+  
+    # Delete configuration for static fields that are not in post
+    static_fields.find_all_by_project_id(project.id).each do |existent_field|
+      unless sent_configured_fields.find {|sent_field| sent_field.is_static? && sent_field.name == existent_field.field_name}
+        to_delete << existent_field
+      end
+    end
+
+    available_issue_custom_field_ids = project.issue_custom_fields.map(&:id)
+
+    # Delete configuration for custom fields that are not available for this project
+    issue_custom_fields.find_all_by_project_id(project.id).each do |existent_field|
+      unless available_issue_custom_field_ids.include?(existent_field.custom_field_id)
+        to_delete << existent_field
+      end
+    end
+
+    # Update configuration
+    sent_configured_fields.each do |sent_field|
+      if sent_field.is_static?
+        record_to_save = find_or_initialize_by_project_id_and_field_name(project.id, sent_field.name)
+      else
+        next unless available_issue_custom_field_ids.include?(sent_field.name.to_i)
+        record_to_save = find_or_initialize_by_project_id_and_custom_field_id(project.id, sent_field.name)
+      end
+
+      record_to_save.active = sent_field.active?
+      to_save << record_to_save
+    end
+
+    transaction do
+      to_delete.map(&:destroy)
+      to_save.map(&:save)
+    end
+  end
+
+  private
+
+  def self.saved_static_configurable_fields_by_name(project)
+    static_fields.find_all_by_project_id(project.id).group_by(&:field_name)
+  end
+
+  def self.saved_configurable_issue_custom_fields_by_id(project)
+    issue_custom_fields.find_all_by_project_id(project.id).group_by(&:custom_field_id)
+  end
+
+  def self.saved_static_configurable_field_is_active?(name, saved_fields_for_project_by_name)
+    return true unless saved_fields_for_project_by_name.has_key?(name)
+    saved_fields_for_project_by_name[name].first.active?
+  end
+
+  def self.saved_configurable_issue_custom_field_is_active?(field_id, saved_fields_for_project_by_id)
+    return true unless saved_fields_for_project_by_id.has_key?(field_id)
+    saved_fields_for_project_by_id[field_id].first.active?
+  end
+
+  def self.static_configurable_fields(project, saved_fields_for_project_by_name)
+    [
+      ConfigurableField.new(:name => 'author', :active => saved_static_configurable_field_is_active?('author', saved_fields_for_project_by_name), :label => I18n.t(:field_author), :is_static => true),
+      ConfigurableField.new(:name => 'status', :active => saved_static_configurable_field_is_active?('status', saved_fields_for_project_by_name), :label => I18n.t(:field_status), :is_static => true),
+      ConfigurableField.new(:name => 'priority', :active => saved_static_configurable_field_is_active?('priority', saved_fields_for_project_by_name), :label => I18n.t(:field_priority), :is_static => true),
+      ConfigurableField.new(:name => 'assigned_to', :active => saved_static_configurable_field_is_active?('assigned_to', saved_fields_for_project_by_name), :label => I18n.t(:field_assigned_to), :is_static => true),
+      ConfigurableField.new(:name => 'category', :active => saved_static_configurable_field_is_active?('category', saved_fields_for_project_by_name), :label => I18n.t(:field_category), :is_static => true),
+      ConfigurableField.new(:name => 'fixed_version', :active => saved_static_configurable_field_is_active?('fixed_version', saved_fields_for_project_by_name), :label => I18n.t(:field_fixed_version), :is_static => true)
+    ]
+  end
+
+  def self.configurable_issue_custom_fields(project, saved_fields_for_project_by_id)
+    project.issue_custom_fields.map do |issue_custom_field|
+      ConfigurableField.new(:name => issue_custom_field.id, :active => self.saved_configurable_issue_custom_field_is_active?(issue_custom_field.id, saved_fields_for_project_by_id) , :label => issue_custom_field.name, :is_static => false)
+    end
+  end
+end

--- a/app/models/email_notification_content_filter_config.rb
+++ b/app/models/email_notification_content_filter_config.rb
@@ -8,7 +8,7 @@ class EmailNotificationContentFilterConfig < ActiveRecord::Base
   scope :issue_custom_fields, :conditions => 'custom_field_id IS NOT NULL'
 
   class ConfigurableField
-    attr_accessor :name, :active, :label, :is_static
+    attr_accessor :name, :active, :label, :is_static, :description
 
     def initialize(fields = {})
       fields.each do |field_name, field_value|
@@ -112,18 +112,18 @@ class EmailNotificationContentFilterConfig < ActiveRecord::Base
 
   def self.static_configurable_fields(project, saved_fields_for_project_by_name)
     [
-      ConfigurableField.new(:name => 'project_name', :active => saved_static_configurable_field_is_active?('project_name', saved_fields_for_project_by_name), :label => I18n.t(:label_project), :is_static => true),
-      ConfigurableField.new(:name => 'tracker_name', :active => saved_static_configurable_field_is_active?('tracker_name', saved_fields_for_project_by_name), :label => I18n.t(:label_tracker), :is_static => true),
-      ConfigurableField.new(:name => 'description', :active => saved_static_configurable_field_is_active?('description', saved_fields_for_project_by_name), :label => I18n.t(:field_description), :is_static => true),
-      ConfigurableField.new(:name => 'subject', :active => saved_static_configurable_field_is_active?('subject', saved_fields_for_project_by_name), :label => I18n.t(:field_subject), :is_static => true),
-      ConfigurableField.new(:name => 'author', :active => saved_static_configurable_field_is_active?('author', saved_fields_for_project_by_name), :label => I18n.t(:field_author), :is_static => true),
-      ConfigurableField.new(:name => 'status', :active => saved_static_configurable_field_is_active?('status', saved_fields_for_project_by_name), :label => I18n.t(:field_status), :is_static => true),
-      ConfigurableField.new(:name => 'priority', :active => saved_static_configurable_field_is_active?('priority', saved_fields_for_project_by_name), :label => I18n.t(:field_priority), :is_static => true),
-      ConfigurableField.new(:name => 'assigned_to', :active => saved_static_configurable_field_is_active?('assigned_to', saved_fields_for_project_by_name), :label => I18n.t(:field_assigned_to), :is_static => true),
-      ConfigurableField.new(:name => 'category', :active => saved_static_configurable_field_is_active?('category', saved_fields_for_project_by_name), :label => I18n.t(:field_category), :is_static => true),
-      ConfigurableField.new(:name => 'fixed_version', :active => saved_static_configurable_field_is_active?('fixed_version', saved_fields_for_project_by_name), :label => I18n.t(:field_fixed_version), :is_static => true),
-      ConfigurableField.new(:name => 'journal_details', :active => saved_static_configurable_field_is_active?('journal_details', saved_fields_for_project_by_name), :label => I18n.t(:label_details), :is_static => true),
-      ConfigurableField.new(:name => 'journal_notes', :active => saved_static_configurable_field_is_active?('journal_notes', saved_fields_for_project_by_name), :label => I18n.t(:field_notes), :is_static => true)
+      ConfigurableField.new(:name => 'project_name', :active => saved_static_configurable_field_is_active?('project_name', saved_fields_for_project_by_name), :label => I18n.t(:label_project), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_project_name_description)),
+      ConfigurableField.new(:name => 'tracker_name', :active => saved_static_configurable_field_is_active?('tracker_name', saved_fields_for_project_by_name), :label => I18n.t(:label_tracker), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_tracker_name_description)),
+      ConfigurableField.new(:name => 'description', :active => saved_static_configurable_field_is_active?('description', saved_fields_for_project_by_name), :label => I18n.t(:field_description), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_description_description)),
+      ConfigurableField.new(:name => 'subject', :active => saved_static_configurable_field_is_active?('subject', saved_fields_for_project_by_name), :label => I18n.t(:field_subject), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_subject_description)),
+      ConfigurableField.new(:name => 'author', :active => saved_static_configurable_field_is_active?('author', saved_fields_for_project_by_name), :label => I18n.t(:field_author), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_author_description)),
+      ConfigurableField.new(:name => 'status', :active => saved_static_configurable_field_is_active?('status', saved_fields_for_project_by_name), :label => I18n.t(:field_status), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_status_description)),
+      ConfigurableField.new(:name => 'priority', :active => saved_static_configurable_field_is_active?('priority', saved_fields_for_project_by_name), :label => I18n.t(:field_priority), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_priority_description)),
+      ConfigurableField.new(:name => 'assigned_to', :active => saved_static_configurable_field_is_active?('assigned_to', saved_fields_for_project_by_name), :label => I18n.t(:field_assigned_to), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_assigned_to_description)),
+      ConfigurableField.new(:name => 'category', :active => saved_static_configurable_field_is_active?('category', saved_fields_for_project_by_name), :label => I18n.t(:field_category), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_category_description)),
+      ConfigurableField.new(:name => 'fixed_version', :active => saved_static_configurable_field_is_active?('fixed_version', saved_fields_for_project_by_name), :label => I18n.t(:field_fixed_version), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_fixed_version_description)),
+      ConfigurableField.new(:name => 'journal_details', :active => saved_static_configurable_field_is_active?('journal_details', saved_fields_for_project_by_name), :label => I18n.t(:label_details), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_journal_details_description)),
+      ConfigurableField.new(:name => 'journal_notes', :active => saved_static_configurable_field_is_active?('journal_notes', saved_fields_for_project_by_name), :label => I18n.t(:field_notes), :is_static => true, :description => I18n.t(:text_email_notification_content_filter_fields_journal_notes_description))
     ]
   end
 

--- a/app/views/mailer/_issue.html.erb
+++ b/app/views/mailer/_issue.html.erb
@@ -1,0 +1,15 @@
+<h1><%= link_to(h("#{issue.tracker.name} ##{issue.id}: #{issue.subject}"), issue_url) %></h1>
+
+<ul>
+<li><%=l(:field_author)%>: <%=h issue.author %></li>
+<li><%=l(:field_status)%>: <%=h issue.status %></li>
+<li><%=l(:field_priority)%>: <%=h issue.priority %></li>
+<li><%=l(:field_assigned_to)%>: <%=h issue.assigned_to %></li>
+<li><%=l(:field_category)%>: <%=h issue.category %></li>
+<li><%=l(:field_fixed_version)%>: <%=h issue.fixed_version %></li>
+<% issue.custom_field_values.each do |c| %>
+  <li><%=h c.custom_field.name %>: <%=h show_value(c) %></li>
+<% end %>
+</ul>
+
+<%= textilizable(issue, :description, :only_path => false) %>

--- a/app/views/mailer/_issue.html.erb
+++ b/app/views/mailer/_issue.html.erb
@@ -1,15 +1,29 @@
-<h1><%= link_to(h("#{issue.tracker.name} ##{issue.id}: #{issue.subject}"), issue_url) %></h1>
+<h1><%= link_to(h(@issue_title), issue_url) %></h1>
 
 <ul>
-<li><%=l(:field_author)%>: <%=h issue.author %></li>
+<%- unless @static_fields_to_hide.include?('author') -%>
+  <li><%=l(:field_author)%>: <%=h issue.author %></li>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('status') -%>
 <li><%=l(:field_status)%>: <%=h issue.status %></li>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('priority') -%>
 <li><%=l(:field_priority)%>: <%=h issue.priority %></li>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('assigned_to') -%>
 <li><%=l(:field_assigned_to)%>: <%=h issue.assigned_to %></li>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('category') -%>
 <li><%=l(:field_category)%>: <%=h issue.category %></li>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('fixed_version') -%>
 <li><%=l(:field_fixed_version)%>: <%=h issue.fixed_version %></li>
-<% issue.custom_field_values.each do |c| %>
+<%- end -%>
+<% @issue_custom_field_values.each do |c| %>
   <li><%=h c.custom_field.name %>: <%=h show_value(c) %></li>
-<% end %>
+<% end -%>
 </ul>
 
+<%- unless @static_fields_to_hide.include?('description') -%>
 <%= textilizable(issue, :description, :only_path => false) %>
+<%- end -%>

--- a/app/views/mailer/_issue.text.erb
+++ b/app/views/mailer/_issue.text.erb
@@ -1,0 +1,13 @@
+<%= "#{issue.tracker.name} ##{issue.id}: #{issue.subject}" %>
+<%= issue_url %>
+
+* <%=l(:field_author)%>: <%= issue.author %>
+* <%=l(:field_status)%>: <%= issue.status %>
+* <%=l(:field_priority)%>: <%= issue.priority %>
+* <%=l(:field_assigned_to)%>: <%= issue.assigned_to %>
+* <%=l(:field_category)%>: <%= issue.category %>
+* <%=l(:field_fixed_version)%>: <%= issue.fixed_version %>
+<% issue.custom_field_values.each do |c| %>* <%= c.custom_field.name %>: <%= show_value(c) %>
+<% end -%>
+----------------------------------------
+<%= issue.description %>

--- a/app/views/mailer/_issue.text.erb
+++ b/app/views/mailer/_issue.text.erb
@@ -1,13 +1,27 @@
-<%= "#{issue.tracker.name} ##{issue.id}: #{issue.subject}" %>
+<%= @issue_title %>
 <%= issue_url %>
 
+<%- unless @static_fields_to_hide.include?('author') -%>
 * <%=l(:field_author)%>: <%= issue.author %>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('status') -%>
 * <%=l(:field_status)%>: <%= issue.status %>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('priority') -%>
 * <%=l(:field_priority)%>: <%= issue.priority %>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('assigned_to') -%>
 * <%=l(:field_assigned_to)%>: <%= issue.assigned_to %>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('category') -%>
 * <%=l(:field_category)%>: <%= issue.category %>
+<%- end -%>
+<%- unless @static_fields_to_hide.include?('fixed_version') -%>
 * <%=l(:field_fixed_version)%>: <%= issue.fixed_version %>
-<% issue.custom_field_values.each do |c| %>* <%= c.custom_field.name %>: <%= show_value(c) %>
+<%- end -%>
+<% @issue_custom_field_values.each do |c| %>* <%= c.custom_field.name %>: <%= show_value(c) %>
 <% end -%>
 ----------------------------------------
+<%- unless @static_fields_to_hide.include?('description') -%>
 <%= issue.description %>
+<%- end -%>

--- a/app/views/mailer/issue_add.html.erb
+++ b/app/views/mailer/issue_add.html.erb
@@ -1,0 +1,3 @@
+<%= l(:text_issue_added, :id => "##{@issue.id}", :author => h(@issue.author)) %>
+<hr />
+<%= render :partial => 'issue', :formats => [:html], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_add.html.erb
+++ b/app/views/mailer/issue_add.html.erb
@@ -1,3 +1,3 @@
-<%= l(:text_issue_added, :id => "##{@issue.id}", :author => h(@issue.author)) %>
+<%= l(:text_issue_added, :id => "##{@issue.id}", :author => h(@author_in_message_title)) %>
 <hr />
 <%= render :partial => 'issue', :formats => [:html], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_add.html.erb
+++ b/app/views/mailer/issue_add.html.erb
@@ -1,3 +1,7 @@
-<%= l(:text_issue_added, :id => "##{@issue.id}", :author => h(@author_in_message_title)) %>
+<% if @author_in_message_title.blank? %>
+  <%= l(:text_issue_added_without_author, :id => "##{@issue.id}") %>
+<% else %>
+  <%= l(:text_issue_added, :id => "##{@issue.id}", :author => h(@author_in_message_title)) %>
+<% end %>
 <hr />
 <%= render :partial => 'issue', :formats => [:html], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_add.text.erb
+++ b/app/views/mailer/issue_add.text.erb
@@ -1,0 +1,4 @@
+<%= l(:text_issue_added, :id => "##{@issue.id}", :author => @issue.author) %>
+
+----------------------------------------
+<%= render :partial => 'issue', :formats => [:text], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_add.text.erb
+++ b/app/views/mailer/issue_add.text.erb
@@ -1,4 +1,4 @@
-<%= l(:text_issue_added, :id => "##{@issue.id}", :author => @issue.author) %>
+<%= l(:text_issue_added, :id => "##{@issue.id}", :author => @author_in_message_title) %>
 
 ----------------------------------------
 <%= render :partial => 'issue', :formats => [:text], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_add.text.erb
+++ b/app/views/mailer/issue_add.text.erb
@@ -1,4 +1,8 @@
-<%= l(:text_issue_added, :id => "##{@issue.id}", :author => @author_in_message_title) %>
+<% if @author_in_message_title.blank? %>
+  <%= l(:text_issue_added_without_author, :id => "##{@issue.id}") %>
+<% else %>
+  <%= l(:text_issue_added, :id => "##{@issue.id}", :author => @author_in_message_title) %>
+<% end %>
 
 ----------------------------------------
 <%= render :partial => 'issue', :formats => [:text], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_edit.html.erb
+++ b/app/views/mailer/issue_edit.html.erb
@@ -1,0 +1,11 @@
+<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => h(@journal.user)) %>
+
+<ul>
+<% details_to_strings(@journal.details, false, :only_path => false).each do |string| %>
+  <li><%= string %></li>
+<% end %>
+</ul>
+
+<%= textilizable(@journal, :notes, :only_path => false) %>
+<hr />
+<%= render :partial => 'issue', :formats => [:html], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_edit.html.erb
+++ b/app/views/mailer/issue_edit.html.erb
@@ -1,4 +1,8 @@
-<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => h(@author_in_message_title)) %>
+<% if @author_in_message_title.blank? %>
+  <%= l(:text_issue_updated_without_author, :id => "##{@issue.id}") %>
+<% else %>
+  <%= l(:text_issue_updated, :id => "##{@issue.id}", :author => h(@author_in_message_title)) %>
+<% end %>
 
 <%- unless @static_fields_to_hide.include?('journal_details') -%>
 <ul>

--- a/app/views/mailer/issue_edit.html.erb
+++ b/app/views/mailer/issue_edit.html.erb
@@ -1,11 +1,15 @@
-<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => h(@journal.user)) %>
+<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => h(@author_in_message_title)) %>
 
+<%- unless @static_fields_to_hide.include?('journal_details') -%>
 <ul>
 <% details_to_strings(@journal.details, false, :only_path => false).each do |string| %>
   <li><%= string %></li>
 <% end %>
 </ul>
+<%- end -%>
 
+<%- unless @static_fields_to_hide.include?('journal_notes') -%>
 <%= textilizable(@journal, :notes, :only_path => false) %>
+<%- end -%>
 <hr />
 <%= render :partial => 'issue', :formats => [:html], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_edit.text.erb
+++ b/app/views/mailer/issue_edit.text.erb
@@ -1,0 +1,12 @@
+<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => @journal.user) %>
+
+<% details_to_strings(@journal.details, true).each do |string| -%>
+<%= string %>
+<% end -%>
+
+<% if @journal.notes? -%>
+<%= @journal.notes %>
+
+<% end -%>
+----------------------------------------
+<%= render :partial => 'issue', :formats => [:text], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/mailer/issue_edit.text.erb
+++ b/app/views/mailer/issue_edit.text.erb
@@ -1,4 +1,8 @@
-<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => @author_in_message_title) %>
+<% if @author_in_message_title.blank? %>
+  <%= l(:text_issue_updated_without_author, :id => "##{@issue.id}", :author => @author_in_message_title) %>
+<% else %>
+  <%= l(:text_issue_updated, :id => "##{@issue.id}", :author => @author_in_message_title) %>
+<% end %>
 
 <%- unless @static_fields_to_hide.include?('journal_details') -%>
 <% details_to_strings(@journal.details, true).each do |string| -%>

--- a/app/views/mailer/issue_edit.text.erb
+++ b/app/views/mailer/issue_edit.text.erb
@@ -1,12 +1,16 @@
-<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => @journal.user) %>
+<%= l(:text_issue_updated, :id => "##{@issue.id}", :author => @author_in_message_title) %>
 
+<%- unless @static_fields_to_hide.include?('journal_details') -%>
 <% details_to_strings(@journal.details, true).each do |string| -%>
 <%= string %>
 <% end -%>
+<%- end -%>
 
+<%- unless @static_fields_to_hide.include?('journal_notes') -%>
 <% if @journal.notes? -%>
 <%= @journal.notes %>
 
 <% end -%>
+<%- end -%>
 ----------------------------------------
 <%= render :partial => 'issue', :formats => [:text], :locals => { :issue => @issue, :issue_url => @issue_url } %>

--- a/app/views/projects/settings/_manage_email_notification_content_filter.html.erb
+++ b/app/views/projects/settings/_manage_email_notification_content_filter.html.erb
@@ -6,7 +6,7 @@
       <th style="width:15%;"><%= l(:field_active) %></th>
     </tr></thead>
 
-    <% EmailNotificationContentFilterConfig.configurable_fields_for_project(@project).each_with_index do |field_config, idx| %>
+    <%- EmailNotificationContentFilterConfig.configurable_fields_for_project(@project).each_with_index do |field_config, idx| -%>
       <tr class="<%= cycle('odd', 'even') %>">
         <td>
           <%= hidden_field_tag "resources[#{idx}][name]", field_config.name %>

--- a/app/views/projects/settings/_manage_email_notification_content_filter.html.erb
+++ b/app/views/projects/settings/_manage_email_notification_content_filter.html.erb
@@ -2,16 +2,20 @@
 
   <table class="list">
     <thead><tr>
-      <th><%= l(:label_email_notification_content_filter_field_name) %></th>
+      <th align="left"><%= l(:label_email_notification_content_filter_field_name) %></th>
+      <th align="left"><%= l(:field_description) %></th>
       <th style="width:15%;"><%= l(:field_active) %></th>
     </tr></thead>
 
     <%- EmailNotificationContentFilterConfig.configurable_fields_for_project(@project).each_with_index do |field_config, idx| -%>
       <tr class="<%= cycle('odd', 'even') %>">
-        <td>
+        <td align="left">
           <%= hidden_field_tag "resources[#{idx}][name]", field_config.name %>
           <%= hidden_field_tag "resources[#{idx}][is_static]", field_config.is_static? %>
           <%= h(field_config.label) %>
+        </td>
+        <td align="left">
+          <%= h(field_config.description) %>
         </td>
         <td align="center" style="width:15%;">
           <%= check_box_tag "resources[#{idx}][active]", "1", field_config.active? %>

--- a/app/views/projects/settings/_manage_email_notification_content_filter.html.erb
+++ b/app/views/projects/settings/_manage_email_notification_content_filter.html.erb
@@ -1,0 +1,24 @@
+<%= form_tag(project_manage_email_notification_content_filter_path(@project), :method => :put, :class => "tabular") do %>
+
+  <table class="list">
+    <thead><tr>
+      <th><%= l(:label_email_notification_content_filter_field_name) %></th>
+      <th style="width:15%;"><%= l(:field_active) %></th>
+    </tr></thead>
+
+    <% EmailNotificationContentFilterConfig.configurable_fields_for_project(@project).each_with_index do |field_config, idx| %>
+      <tr class="<%= cycle('odd', 'even') %>">
+        <td>
+          <%= hidden_field_tag "resources[#{idx}][name]", field_config.name %>
+          <%= hidden_field_tag "resources[#{idx}][is_static]", field_config.is_static? %>
+          <%= h(field_config.label) %>
+        </td>
+        <td align="center" style="width:15%;">
+          <%= check_box_tag "resources[#{idx}][active]", "1", field_config.active? %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+
+  <%= submit_tag l(:button_save) %>
+<% end %>

--- a/app/views/settings/_email_notification_content_filter.html.erb
+++ b/app/views/settings/_email_notification_content_filter.html.erb
@@ -1,4 +1,0 @@
-<u><b><%= l(:fieldsToRemove)%></b></u><br/><br/>
-<%= check_box_tag('settings[removeDescription]', @settings['removeDescription'], @settings['removeDescription']) %> <%= l(:description)%> <br/>
-<%= check_box_tag('settings[removeNote]', @settings['removeNote'], @settings['removeNote']) %> <%= l(:notes)%> <br/>
-<%= check_box_tag('settings[removeSubject]', @settings['removeSubject'], @settings['removeSubject']) %> <%= l(:subject)%>

--- a/app/views/settings/_email_notification_content_filter.html.erb
+++ b/app/views/settings/_email_notification_content_filter.html.erb
@@ -2,5 +2,3 @@
 <%= check_box_tag('settings[removeDescription]', @settings['removeDescription'], @settings['removeDescription']) %> <%= l(:description)%> <br/>
 <%= check_box_tag('settings[removeNote]', @settings['removeNote'], @settings['removeNote']) %> <%= l(:notes)%> <br/>
 <%= check_box_tag('settings[removeSubject]', @settings['removeSubject'], @settings['removeSubject']) %> <%= l(:subject)%>
-
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,5 @@ en:
   email_notification_content_filter_configuration_tab: Notification content filter
   label_email_notification_content_filter_field_name: Field
   notice_email_notification_content_filter_failed_to_save_config: Failed to save config
+  text_issue_added_without_author: Issue %{id} has been reported
+  text_issue_updated_without_author: Issue %{id} has been updated

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,11 +1,6 @@
 # English strings go here for Rails i18n
 en:
-  fieldsToRemove: Fields to remove
-  description: Description
-  notes: Notes
-  subject: Subject
   project_module_email_notification_content_filter: Email notification content filter
-
-  email_notification_content_filter_configuration_tab: Email content
+  email_notification_content_filter_configuration_tab: Notification content filter
   label_email_notification_content_filter_field_name: Field
   notice_email_notification_content_filter_failed_to_save_config: Failed to save config

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,7 @@ en:
   notes: Notes
   subject: Subject
   project_module_email_notification_content_filter: Email notification content filter
+
+  email_notification_content_filter_configuration_tab: Email content
+  label_email_notification_content_filter_field_name: Field
+  notice_email_notification_content_filter_failed_to_save_config: Failed to save config

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,15 @@ en:
   notice_email_notification_content_filter_failed_to_save_config: Failed to save config
   text_issue_added_without_author: Issue %{id} has been reported
   text_issue_updated_without_author: Issue %{id} has been updated
+  text_email_notification_content_filter_fields_project_name_description: 'Project name'
+  text_email_notification_content_filter_fields_tracker_name_description: 'Tracker name'
+  text_email_notification_content_filter_fields_description_description: 'Issue description'
+  text_email_notification_content_filter_fields_subject_description: 'Issue subject'
+  text_email_notification_content_filter_fields_author_description: 'Issue reporter or updater'
+  text_email_notification_content_filter_fields_status_description: 'Issue status'
+  text_email_notification_content_filter_fields_priority_description: 'Issue priority'
+  text_email_notification_content_filter_fields_assigned_to_description: 'Issue assignee'
+  text_email_notification_content_filter_fields_category_description: 'Issue category'
+  text_email_notification_content_filter_fields_fixed_version_description: 'Issue target version'
+  text_email_notification_content_filter_fields_journal_details_description: 'Issue modification details'
+  text_email_notification_content_filter_fields_journal_notes_description: 'Issue modification notes'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,6 @@
+it:
+  fieldsToRemove: Campi da rimuovere
+  description: Descrizione
+  notes: Note
+  subject: Oggetto
+  project_module_email_notification_content_filter: Email notification content filter

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -3,3 +3,17 @@ it:
   email_notification_content_filter_configuration_tab: Contenuti delle notifiche
   label_email_notification_content_filter_field_name: Campo
   notice_email_notification_content_filter_failed_to_save_config: Impossibile salvare la configurazione
+  text_issue_added_without_author: E' stata segnalata l'anomalia %{id}
+  text_issue_updated_without_author: L'anomalia %{id} è stata aggiornata
+  text_email_notification_content_filter_fields_project_name_description: 'Nome del progetto'
+  text_email_notification_content_filter_fields_tracker_name_description: 'Nome del tracker'
+  text_email_notification_content_filter_fields_description_description: 'Descrizione della segnalazione'
+  text_email_notification_content_filter_fields_subject_description: 'Oggetto della segnalazione'
+  text_email_notification_content_filter_fields_author_description: 'Autore della segnalazione o della modifica'
+  text_email_notification_content_filter_fields_status_description: 'Stato della segnalazione'
+  text_email_notification_content_filter_fields_priority_description: 'Priorità della segnalazione'
+  text_email_notification_content_filter_fields_assigned_to_description: 'Assegnatario della segnalazione'
+  text_email_notification_content_filter_fields_category_description: 'Categoria della segnalazione'
+  text_email_notification_content_filter_fields_fixed_version_description: 'Versione prevista'
+  text_email_notification_content_filter_fields_journal_details_description: 'Dettagli della modifica alla segnalazione'
+  text_email_notification_content_filter_fields_journal_notes_description: 'Note della modifica alla segnalazione'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,5 @@
 it:
-  fieldsToRemove: Campi da rimuovere
-  description: Descrizione
-  notes: Note
-  subject: Oggetto
-  project_module_email_notification_content_filter: Email notification content filter
+  project_module_email_notification_content_filter: Filtri sui contenuti delle email di notifica
+  email_notification_content_filter_configuration_tab: Contenuti delle notifiche
+  label_email_notification_content_filter_field_name: Campo
+  notice_email_notification_content_filter_failed_to_save_config: Impossibile salvare la configurazione

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,7 +1,3 @@
 # Portuguese strings go here for Rails i18n
 pt:
-  fieldsToRemove: Campos a remover
-  description: Descrição
-  notes: Notas
-  subject: Assunto
   project_module_email_notification_content_filter: Filtro de conteúdo dos emails de notificação

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,5 @@
+RedmineApp::Application.routes.draw do
+  resources :projects do
+    resource :manage_email_notification_content_filter, :controller => 'email_notification_content_filter', :only => [:update]
+  end
+end

--- a/db/migrate/001_create_email_notification_content_filter_configs.rb
+++ b/db/migrate/001_create_email_notification_content_filter_configs.rb
@@ -1,0 +1,12 @@
+class CreateEmailNotificationContentFilterConfigs < ActiveRecord::Migration
+  def change
+    create_table :email_notification_content_filter_configs do |t|
+      t.references :project
+      t.string :field_name
+      t.references :custom_field
+      t.boolean :active
+    end
+    add_index :email_notification_content_filter_configs, :project_id, :name => :email_content_filter_config_project
+    add_index :email_notification_content_filter_configs, :custom_field_id, :name => :email_content_filter_custom_field
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -9,8 +9,12 @@ Redmine::Plugin.register :redmine_email_notification_content_filter do
   author_url 'mailto:sleroux@keep.pt'
   url 'https://github.com/keeps/redmine_email_notification_content_filter'
   project_module :email_notification_content_filter do
-    permission :manage, {:email_notification_content_filter => :manage}
+    permission :manage, {
+      :email_notification_content_filter => [ :manage, :update ]
+    }
   end
+  
+  requires_redmine :version_or_higher => '2.2'
 end
 
 ActionDispatch::Callbacks.to_prepare do

--- a/init.rb
+++ b/init.rb
@@ -9,7 +9,6 @@ Redmine::Plugin.register :redmine_email_notification_content_filter do
   author_url 'mailto:sleroux@keep.pt'
   url 'https://github.com/keeps/redmine_email_notification_content_filter'
   project_module :email_notification_content_filter do
-    permission :block_email, {:email_notification_content_filter => :show}
     permission :manage, {:email_notification_content_filter => :manage}
   end
 end

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,4 @@
-require 'redmine'
-require 'dispatcher'
+﻿require 'redmine'
 require 'mailer_patch'
 
 Redmine::Plugin.register :redmine_email_notification_content_filter do
@@ -19,7 +18,7 @@ Redmine::Plugin.register :redmine_email_notification_content_filter do
   end
 end
 
-Dispatcher.to_prepare do
-	 require_dependency 'mailer'
+ActionDispatch::Callbacks.to_prepare do
+	require_dependency 'mailer'
   Mailer.send(:include, MailerPatch)
 end

--- a/init.rb
+++ b/init.rb
@@ -15,10 +15,13 @@ Redmine::Plugin.register :redmine_email_notification_content_filter do
   }, :partial => 'settings/email_notification_content_filter'
   project_module :email_notification_content_filter do
     permission :block_email, {:email_notification_content_filter => :show}
+    permission :manage, {:email_notification_content_filter => :manage}
   end
 end
 
 ActionDispatch::Callbacks.to_prepare do
 	require_dependency 'mailer'
   Mailer.send(:include, MailerPatch)
+  Project.send(:include, ProjectPatch)
+  ProjectsHelper.send(:include, ProjectsHelperPatch)
 end

--- a/init.rb
+++ b/init.rb
@@ -8,11 +8,6 @@ Redmine::Plugin.register :redmine_email_notification_content_filter do
   version '0.0.1'
   author_url 'mailto:sleroux@keep.pt'
   url 'https://github.com/keeps/redmine_email_notification_content_filter'
-  settings :default => {
-    'removeDescriptionFromDocument' => 'false',
-    'removeDescriptionFromNews' => 'false',
-    'removeDescriptionFromIssue' => 'false'
-  }, :partial => 'settings/email_notification_content_filter'
   project_module :email_notification_content_filter do
     permission :block_email, {:email_notification_content_filter => :show}
     permission :manage, {:email_notification_content_filter => :manage}

--- a/lib/mailer_patch.rb
+++ b/lib/mailer_patch.rb
@@ -11,52 +11,104 @@ module MailerPatch
   module InstanceMethods
     # Copied from app/models/mailer.rb
     def issue_add_with_email_filter(issue)
-      if issue.project.module_enabled?('email_notification_content_filter')
-        if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
-          issue.description = ""
-        end
-        if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
-          issue.subject = ""
-        end
+      @issue_custom_field_values = issue.custom_field_values
+      @static_fields_to_hide = {}
+
+      if issue.project.module_enabled?(:email_notification_content_filter)
+        project = issue.project
+        email_content_filter_config = EmailNotificationContentFilterConfig.find_all_by_project_id(project.id)
+
+        @static_fields_to_hide = EmailNotificationContentFilterConfig.static_field_to_hide_names(email_content_filter_config)
+        
+        issue_custom_field_to_remove_ids = EmailNotificationContentFilterConfig.issue_custom_field_to_remove_ids(email_content_filter_config)
+        @issue_custom_field_values = @issue_custom_field_values.select {|custom_field_value| !issue_custom_field_to_remove_ids.include?(custom_field_value.custom_field.id) }
       end
-      issue_add_without_email_filter(issue)
+
+      @issue_title = email_notification_content_filter_issue_title(issue.id, issue.project.name, issue.tracker.name, issue.status.name, issue.subject)
+      @author_in_message_title = @static_fields_to_hide.include?('project_name') ? "" : issue.author
+      s = email_notification_content_filter_subject(issue.id, issue.project.name, issue.tracker.name, issue.status.name, issue.subject)
+
+      redmine_headers 'Project' => issue.project.identifier,
+                      'Issue-Id' => issue.id,
+                      'Issue-Author' => issue.author.login
+      redmine_headers 'Issue-Assignee' => issue.assigned_to.login if issue.assigned_to
+      message_id issue
+      @author = issue.author
+      @issue = issue
+      @issue_url = url_for(:controller => 'issues', :action => 'show', :id => issue)
+
+      recipients = issue.recipients
+      cc = issue.watcher_recipients - recipients
+      mail :to => recipients,
+        :cc => cc,
+        :subject => s
     end
 
+    # Copied from app/models/mailer.rb
     def issue_edit_with_email_filter(journal)
       issue = journal.journalized.reload
-      if issue.project.module_enabled?('email_notification_content_filter')
-        if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
-          issue.description = ""
-        end
-        if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
-          issue.subject = ""
-        end
+
+      @issue_custom_field_values = issue.custom_field_values
+      @static_fields_to_hide = {}
+
+      if issue.project.module_enabled?(:email_notification_content_filter)
+        project = issue.project
+        email_content_filter_config = EmailNotificationContentFilterConfig.find_all_by_project_id(project.id)
+
+        @static_fields_to_hide = EmailNotificationContentFilterConfig.static_field_to_hide_names(email_content_filter_config)
+        
+        issue_custom_field_to_remove_ids = EmailNotificationContentFilterConfig.issue_custom_field_to_remove_ids(email_content_filter_config)
+        @issue_custom_field_values = @issue_custom_field_values.select {|custom_field_value| !issue_custom_field_to_remove_ids.include?(custom_field_value.custom_field.id) }
       end
+
       redmine_headers 'Project' => issue.project.identifier,
-        'Issue-Id' => issue.id,
-        'Issue-Author' => issue.author.login
+                      'Issue-Id' => issue.id,
+                      'Issue-Author' => issue.author.login
       redmine_headers 'Issue-Assignee' => issue.assigned_to.login if issue.assigned_to
       message_id journal
       references issue
-      if Setting.plugin_redmine_email_notification_content_filter['removeNote']
-        journal.notes = ""
-      end
       @author = journal.user
-      to_recipients = issue.recipients
+      recipients = journal.recipients
       # Watchers in cc
-      cc_recipients = issue.watcher_recipients - to_recipients
-      s = "[#{issue.project.name} - #{issue.tracker.name} ##{issue.id}] "
-      s << "(#{issue.status.name}) " if journal.new_value_for('status_id')
-      s << issue.subject
+      cc = journal.watcher_recipients - recipients
+      
+      @issue_title = email_notification_content_filter_issue_title(issue.id, issue.project.name, issue.tracker.name, issue.status.name, issue.subject)
+      @author_in_message_title = @static_fields_to_hide.include?('project_name') ? "" : journal.user
+      status_name = journal.new_value_for('status_id') ? issue.status.name : ""
+      s = email_notification_content_filter_subject(issue.id, issue.project.name, issue.tracker.name, status_name, issue.subject)
 
       @issue = issue
       @journal = journal
       @issue_url = url_for(:controller => 'issues', :action => 'show', :id => issue, :anchor => "change-#{journal.id}")
+      mail :to => recipients,
+        :cc => cc,
+        :subject => s
+    end
 
-      mail(:to => to_recipients, :subject => s, :template_name => 'issue_edit') do |format|
-        format.html
-        format.text
+    private
+    def email_notification_content_filter_issue_title(issue_id, project_name, tracker_name, status_name, issue_subject)
+      issue_title = "#{tracker_name} ##{issue_id}: #{issue_subject}"
+
+      issue_title = "##{issue_id}"
+      issue_title = "#{tracker_name} #{issue_title}" unless @static_fields_to_hide.include?('tracker_name')
+      issue_title << ": #{issue_subject}" unless @static_fields_to_hide.include?('subject')
+      issue_title
+    end
+
+    def email_notification_content_filter_subject(issue_id, project_name, tracker_name, status_name, issue_subject)
+      subject_head = []
+      subject_head << project_name unless @static_fields_to_hide.include?('project_name')
+      subject_head << tracker_name unless @static_fields_to_hide.include?('tracker_name')
+      if subject_head.empty?
+        subject_head_str = "##{issue_id}"
+      else
+        subject_head_str = "#{subject_head.join(' - ')} ##{issue_id}"
       end
+
+      subject_str = "[#{subject_head_str}]"
+      subject_str << " (#{status_name})" unless @static_fields_to_hide.include?('status') || status_name.blank?
+      subject_str << " #{issue_subject}" unless @static_fields_to_hide.include?('subject')
+      subject_str
     end
   end
 end

--- a/lib/mailer_patch.rb
+++ b/lib/mailer_patch.rb
@@ -1,5 +1,5 @@
 module MailerPatch
-    def self.included(base) # :nodoc:
+  def self.included(base) # :nodoc:
     base.send(:include, InstanceMethods)
 
     base.class_eval do
@@ -10,49 +10,51 @@ module MailerPatch
 
   module InstanceMethods
     def issue_add_with_email_filter(issue)
-	if issue.project.module_enabled?('email_notification_content_filter')
-		if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
-			issue.description=""
-		end
-		if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
-			issue.subject=""
-		end
-	end
-	issue_add_without_email_filter(issue)
+      if issue.project.module_enabled?('email_notification_content_filter')
+        if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
+          issue.description=""
+        end
+        if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
+          issue.subject=""
+        end
+      end
+      issue_add_without_email_filter(issue)
     end
     def issue_edit_with_email_filter(journal)
-	issue = journal.journalized.reload
-	if issue.project.module_enabled?('email_notification_content_filter')
-		if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
-			issue.description=""
-		end
-		if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
-			issue.subject=""
-		end
-	end
-    redmine_headers 'Project' => issue.project.identifier,
-                    'Issue-Id' => issue.id,
-                    'Issue-Author' => issue.author.login
-    redmine_headers 'Issue-Assignee' => issue.assigned_to.login if issue.assigned_to
-    message_id journal
-    references issue
-    if Setting.plugin_redmine_email_notification_content_filter['removeNote']
-	journal.notes=""
-    end
-    @author = journal.user
-    recipients issue.recipients
-    # Watchers in cc
-    cc(issue.watcher_recipients - @recipients)
-    s = "[#{issue.project.name} - #{issue.tracker.name} ##{issue.id}] "
-    s << "(#{issue.status.name}) " if journal.new_value_for('status_id')
-    s << issue.subject
-    subject s
-    body :issue => issue,
-         :journal => journal,
-         :issue_url => url_for(:controller => 'issues', :action => 'show', :id => issue, :anchor => "change-#{journal.id}")
+      issue = journal.journalized.reload
+      if issue.project.module_enabled?('email_notification_content_filter')
+        if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
+          issue.description=""
+        end
+        if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
+          issue.subject=""
+        end
+      end
+      redmine_headers 'Project' => issue.project.identifier,
+        'Issue-Id' => issue.id,
+        'Issue-Author' => issue.author.login
+      redmine_headers 'Issue-Assignee' => issue.assigned_to.login if issue.assigned_to
+      message_id journal
+      references issue
+      if Setting.plugin_redmine_email_notification_content_filter['removeNote']
+        journal.notes=""
+      end
+      @author = journal.user
+      to_recipients = issue.recipients
+      # Watchers in cc
+      cc_recipients = issue.watcher_recipients - to_recipients
+      s = "[#{issue.project.name} - #{issue.tracker.name} ##{issue.id}] "
+      s << "(#{issue.status.name}) " if journal.new_value_for('status_id')
+      s << issue.subject
 
-    render_multipart('issue_edit', body)
-    end
+      @issue = issue
+      @journal = journal
+      @issue_url = url_for(:controller => 'issues', :action => 'show', :id => issue, :anchor => "change-#{journal.id}")
 
+      mail(:to => to_recipients, :subject => s, :template_name => 'issue_edit') do |format|
+        format.html
+        format.text
+      end
+    end
   end
-  end
+end

--- a/lib/mailer_patch.rb
+++ b/lib/mailer_patch.rb
@@ -9,25 +9,27 @@ module MailerPatch
   end
 
   module InstanceMethods
+    # Copied from app/models/mailer.rb
     def issue_add_with_email_filter(issue)
       if issue.project.module_enabled?('email_notification_content_filter')
         if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
-          issue.description=""
+          issue.description = ""
         end
         if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
-          issue.subject=""
+          issue.subject = ""
         end
       end
       issue_add_without_email_filter(issue)
     end
+
     def issue_edit_with_email_filter(journal)
       issue = journal.journalized.reload
       if issue.project.module_enabled?('email_notification_content_filter')
         if Setting.plugin_redmine_email_notification_content_filter['removeDescription']
-          issue.description=""
+          issue.description = ""
         end
         if Setting.plugin_redmine_email_notification_content_filter['removeSubject']
-          issue.subject=""
+          issue.subject = ""
         end
       end
       redmine_headers 'Project' => issue.project.identifier,
@@ -37,7 +39,7 @@ module MailerPatch
       message_id journal
       references issue
       if Setting.plugin_redmine_email_notification_content_filter['removeNote']
-        journal.notes=""
+        journal.notes = ""
       end
       @author = journal.user
       to_recipients = issue.recipients

--- a/lib/mailer_patch.rb
+++ b/lib/mailer_patch.rb
@@ -25,7 +25,7 @@ module MailerPatch
       end
 
       @issue_title = email_notification_content_filter_issue_title(issue.id, issue.project.name, issue.tracker.name, issue.status.name, issue.subject)
-      @author_in_message_title = @static_fields_to_hide.include?('project_name') ? "" : issue.author
+      @author_in_message_title = @static_fields_to_hide.include?('author') ? "" : issue.author
       s = email_notification_content_filter_subject(issue.id, issue.project.name, issue.tracker.name, issue.status.name, issue.subject)
 
       redmine_headers 'Project' => issue.project.identifier,
@@ -73,7 +73,7 @@ module MailerPatch
       cc = journal.watcher_recipients - recipients
       
       @issue_title = email_notification_content_filter_issue_title(issue.id, issue.project.name, issue.tracker.name, issue.status.name, issue.subject)
-      @author_in_message_title = @static_fields_to_hide.include?('project_name') ? "" : journal.user
+      @author_in_message_title = @static_fields_to_hide.include?('author') ? "" : journal.user
       status_name = journal.new_value_for('status_id') ? issue.status.name : ""
       s = email_notification_content_filter_subject(issue.id, issue.project.name, issue.tracker.name, status_name, issue.subject)
 

--- a/lib/project_patch.rb
+++ b/lib/project_patch.rb
@@ -1,0 +1,12 @@
+module ProjectPatch
+  def self.included(base) # :nodoc:
+    base.send(:include, InstanceMethods)
+
+    base.class_eval do
+      has_many :email_notification_content_filter_configs, :dependent => :destroy
+    end
+  end
+
+  module InstanceMethods
+  end
+end

--- a/lib/projects_helper_patch.rb
+++ b/lib/projects_helper_patch.rb
@@ -1,0 +1,29 @@
+module ProjectsHelperPatch
+  def self.included(base) # :nodoc:
+    base.send(:include, InstanceMethods)
+
+    base.class_eval do
+      alias_method_chain :project_settings_tabs, :email_filter
+    end
+  end
+
+  module InstanceMethods
+    # Copied from app/helpers/projects_helper.rb
+    def project_settings_tabs_with_email_filter
+      tabs = project_settings_tabs_without_email_filter
+      tabs = tabs.select {|tab| User.current.allowed_to?(tab[:action], @project)}
+
+      action_permission = { :controller => :email_notification_content_filter, :action => :manage }
+      if User.current.allowed_to?(action_permission, @project)
+        tabs << {
+          :name => 'email_filter',
+          :action => :manage_email_notification_content_filter,
+          :partial => 'projects/settings/manage_email_notification_content_filter',
+          :label => :email_notification_content_filter_configuration_tab
+        }
+      end
+
+      tabs
+    end
+  end
+end

--- a/test/functional/email_notification_content_filter_controller_test.rb
+++ b/test/functional/email_notification_content_filter_controller_test.rb
@@ -1,0 +1,8 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class EmailNotificationContentFilterControllerTest < ActionController::TestCase
+  # Replace this with your real tests.
+  def test_truth
+    assert true
+  end
+end

--- a/test/unit/email_notification_content_filter_config_test.rb
+++ b/test/unit/email_notification_content_filter_config_test.rb
@@ -1,0 +1,9 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class EmailNotificationContentFilterConfigTest < ActiveSupport::TestCase
+
+  # Replace this with your real tests.
+  def test_truth
+    assert true
+  end
+end


### PR DESCRIPTION
I added a project based configuration: for each project is configurable each available filter on email content.
This drastically changes the behaviour of the plugin which was previously only partially configurable system wide.
![configurable_content_filter](https://f.cloud.github.com/assets/440593/349359/88b3f41e-9fbe-11e2-91cb-79fe02af76b6.jpg)
